### PR TITLE
Fixes #29 - Stop adding lifetimes to trait generic params

### DIFF
--- a/entrait_macros/src/analyze_generics.rs
+++ b/entrait_macros/src/analyze_generics.rs
@@ -214,7 +214,7 @@ impl GenericsAnalyzer {
             })?;
 
         for (index, param) in generic_params.iter().enumerate() {
-            if index != matching_index {
+            if index != matching_index && !(matches!(param, &syn::GenericParam::Lifetime(_))) {
                 self.trait_generics.params.push(param.clone());
             }
         }

--- a/tests/it/dependency_inversion.rs
+++ b/tests/it/dependency_inversion.rs
@@ -167,3 +167,31 @@ mod async_dyn {
         assert_eq!(1337, app.bar().await);
     }
 }
+
+mod issue_29 {
+    use entrait::*;
+
+    #[entrait(FoobarImpl, delegate_by = DelegateFoobar)]
+    pub trait Foobar {
+        fn foo<'a>(&self, input: &'a str) -> &'a str;
+    }
+
+    pub struct MyImpl;
+
+    #[entrait]
+    impl FoobarImpl for MyImpl {
+        fn foo<'a, D>(deps: &D, input: &'a str) -> &'a str {
+            input
+        }
+    }
+
+    impl DelegateFoobar<Self> for () {
+        type Target = MyImpl;
+    }
+
+    #[test]
+    fn test_mod() {
+        let app = Impl::new(());
+        assert_eq!("foo", app.foo("foo"));
+    }
+}


### PR DESCRIPTION
Fixes #29. I do not have much experience with proc macros so diving into this was my baptism by fire. I hope I've made the change in the correct place! 🤞 

Look forward to your review.